### PR TITLE
chore: bump rhiza template to v0.13.3

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.10.3"
+template-branch: "v0.13.3"
 
 templates:
   - devcontainer


### PR DESCRIPTION
## Summary
- Bumps rhiza template to v0.13.3
- Syncs template-managed files via `make sync`
- Conflicts resolved by accepting template (theirs) version

Generated with Claude Code