### PR TITLE
test: skip render tests without graphviz, and document the last helpers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,23 @@ Security Notes:
 - S603/S607 (subprocess usage): Any subprocess calls use controlled inputs in test environments
 """
 
+import shutil
+
+import pytest
+
 from loman import Computation, ComputationFactory, calc_node, input_node
+
+# Rendering a graph or a widget goes through pydotplus, which shells out to
+# graphviz's `dot`. `make install` provisions that binary via the pre-install hook
+# in .rhiza/make.d/00-additional-deps.mk, so it is always there for `make test` and
+# for local work -- but CI jobs that call `uv run pytest` directly never trigger
+# make, and every render-dependent assertion then fails on the same
+# InvocationException. Skip those modules rather than reporting a missing system
+# package as ~106 test failures.
+requires_dot = pytest.mark.skipif(
+    shutil.which("dot") is None,
+    reason="graphviz 'dot' is not on PATH; install it with scripts/install-graphviz.sh",
+)
 
 
 @ComputationFactory

--- a/tests/test_computeengine.py
+++ b/tests/test_computeengine.py
@@ -54,7 +54,7 @@ from loman.computeengine import (
 from loman.exception import NodeAlreadyExistsException, NonExistentNodeException
 from loman.nodekey import to_nodekey
 from loman.visualization import GraphView
-from tests.conftest import BasicFourNodeComputation
+from tests.conftest import BasicFourNodeComputation, requires_dot
 
 
 def test_computation_subscription_batches_public_mutations():
@@ -2003,6 +2003,7 @@ class _InstrumentBlock:
 
     @calc_node
     def value(self, data, scale):
+        """Scale the block's input, giving each repeated block a distinct result."""
         return data * scale
 
 
@@ -4244,6 +4245,7 @@ class TestGetDescendentsInternal:
         assert to_nodekey("c") in descendents
 
 
+@requires_dot
 class TestReprSvg:
     """Tests for Computation._repr_svg_."""
 
@@ -4362,6 +4364,11 @@ class TestUnsubscribedComputationsPayNothing:
 
     @staticmethod
     def _chain(length: int) -> Computation:
+        """Build a linear chain of ``length`` nodes, each incrementing its predecessor.
+
+        Only ``x0`` carries a value; the rest stay uncomputed, so inserting into
+        ``x0`` makes every descendant stale in one propagation pass.
+        """
         comp = Computation()
         comp.add_node("x0", value=0.0)
         for i in range(1, length):
@@ -4370,6 +4377,12 @@ class TestUnsubscribedComputationsPayNothing:
 
     @staticmethod
     def _count_hashes(action) -> int:
+        """Count how many times ``NodeKey.__hash__`` runs while ``action`` executes.
+
+        Patches the dunder for the duration of the call and restores it in a
+        ``finally``, so an exception in ``action`` cannot leak the counter into
+        later tests.
+        """
         original = NodeKey.__hash__
         calls = [0]
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -320,25 +320,17 @@ def test_nd_array_transformer():
 class Foo:
     """Base test class for transformer subtype testing."""
 
-    pass
-
 
 class FooA(Foo):
     """Subclass A of Foo for testing."""
-
-    pass
 
 
 class FooB(Foo):
     """Subclass B of Foo for testing."""
 
-    pass
-
 
 class FooUnregistered(Foo):
     """Unregistered subclass of Foo for testing."""
-
-    pass
 
 
 class FooTransformer(CustomTransformer):

--- a/tests/test_ui_widget.py
+++ b/tests/test_ui_widget.py
@@ -22,7 +22,12 @@ from loman.nodekey import to_nodekey
 from loman.ui import ComputationWidget
 from loman.ui.viewmodel import MIXED_STATE_LABEL
 from loman.visualization import GraphView
-from tests.conftest import create_example_block_computation
+from tests.conftest import create_example_block_computation, requires_dot
+
+# The widget renders its graph through graphviz on construction; without `dot`
+# every view is None and the assertions below fail on that rather than on anything
+# this module is testing.
+pytestmark = requires_dot
 
 STATIC = Path(__file__).parents[1] / "src" / "loman" / "ui" / "static"
 
@@ -2349,7 +2354,7 @@ class TestEveryNameSurfaceKeepsItsType:
             for attribute, value in vars(ComputationWidget).items()
             if isinstance(value, property)
             and not attribute.startswith("_")
-            and (attribute.endswith("_name") or attribute.endswith("_names"))
+            and (attribute.endswith(("_name", "_names")))
         )
 
     def test_the_sweep_actually_covers_something(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1073,7 +1073,7 @@ class TestAttributeView:
         assert "get_item" in state
 
         # Create new AttributeView and restore state
-        new_av = AttributeView(lambda: [], lambda x: None)
+        new_av = AttributeView(list, lambda x: None)
         new_av.__setstate__(state)
         assert new_av.a == 1
 
@@ -1089,7 +1089,7 @@ class TestAttributeView:
         state = av.__getstate__()
         assert state["get_item"] is None
 
-        new_av = AttributeView(lambda: [], lambda x: None)
+        new_av = AttributeView(list, lambda x: None)
         new_av.__setstate__(state)
         # After setstate with get_item=None, get_item should default to get_attribute
         assert new_av["a"] == 1

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -42,6 +42,7 @@ from loman.visualization import (
 from tests.conftest import (
     BasicFourNodeComputation,
     create_example_block_computation,
+    requires_dot,
 )
 
 
@@ -880,6 +881,7 @@ class TestGraphViewRendering:
         v.viz_dot = None
         assert v.svg() is None
 
+    @requires_dot
     def test_graph_view_repr_svg(self):
         """Test GraphView._repr_svg_() method."""
         comp = Computation()
@@ -891,6 +893,7 @@ class TestGraphViewRendering:
 
     @patch("subprocess.run")
     @patch("tempfile.NamedTemporaryFile")
+    @requires_dot
     def test_graph_view_view_linux(self, mock_tempfile, mock_run):
         """Test GraphView.view() on Linux."""
         comp = Computation()
@@ -983,6 +986,7 @@ class TestVisualizationAttrNormalization:
         assert root is not None
 
 
+@requires_dot
 class TestGraphViewCollapse:
     """Tests for GraphView with collapse_all."""
 
@@ -1008,6 +1012,7 @@ class TestGraphViewCollapse:
         assert svg is not None
 
 
+@requires_dot
 class TestGraphViewEmpty:
     """Test GraphView with empty computation."""
 
@@ -1022,6 +1027,7 @@ class TestGraphViewEmpty:
         assert "<svg" in svg
 
 
+@requires_dot
 class TestVisualizationWin32Branch:
     """Test the Windows platform branch in view()."""
 
@@ -1055,6 +1061,7 @@ class TestVisualizationCalibrate:
         f.calibrate([])  # Should do nothing, no error
 
 
+@requires_dot
 class TestCollapseNodeMapped:
     """Test the collapse logic in visualization."""
 
@@ -1129,6 +1136,7 @@ class TestVisualizationOpenPdf:
         assert "open" in mock_run.call_args[0][0]
 
 
+@requires_dot
 class TestVisualizationWithNoneCmap:
     """Test visualization with None colormap."""
 
@@ -1196,6 +1204,7 @@ class TestRenameMetadataClearBranch:
         assert comp.metadata("new_name") == {}
 
 
+@requires_dot
 class TestGraphViewWithRootNode:
     """Test GraphView with root parameter filtering."""
 
@@ -1212,6 +1221,7 @@ class TestGraphViewWithRootNode:
         assert svg is not None
 
 
+@requires_dot
 class TestGraphViewNoneFormatter:
     """Tests for GraphView with node_formatter=None."""
 
@@ -1225,6 +1235,7 @@ class TestGraphViewNoneFormatter:
         assert svg is not None
 
 
+@requires_dot
 class TestColormapNodeFormatter:
     """Tests for colormap in node formatter."""
 
@@ -1251,6 +1262,7 @@ class TestColormapNodeFormatter:
         assert svg is not None
 
 
+@requires_dot
 class TestGraphViewTransformations:
     """Test GraphView with transformations."""
 
@@ -1270,6 +1282,7 @@ class TestGraphViewTransformations:
         assert svg is not None
 
 
+@requires_dot
 class TestVisualizationDropRootNone:
     """Test visualization when drop_root returns None."""
 
@@ -1314,6 +1327,7 @@ class TestVisualizationSubprocess:
 class TestVisualizationVizDagFormatterNone:
     """Test create_viz_dag with node_formatter=None."""
 
+    @requires_dot
     def test_create_viz_dag_no_formatter(self):
         """Test create_viz_dag without node formatter."""
         comp = Computation()


### PR DESCRIPTION
Test-suite changes, split out of the rhiza v1.3.3 branch (#69). Touches only `tests/`.

## Graphviz

Rendering shells out to `dot`, installed by the pre-install hook via `scripts/install-graphviz.sh` — so it is there for `make test`, for the CI matrix job that runs `make test`, and locally. A CI job that calls `uv run pytest` **directly** never triggers make, and 107 tests then fail on the same missing system package.

There is no way to fix that from this side: the job lives in the reusable workflow at `jebel-quant/rhiza` and the local wrapper can only forward secrets. No pip-installable graphviz binary exists either (`graphviz-binary`, `graphviz-bin`, `dot-binary` all 404 on PyPI).

So `requires_dot` in `tests/conftest.py` skips them, applied as narrowly as the failures allow:

| Module | Scope | Still runs |
| --- | --- | --- |
| `test_visualization` | 10 classes + 3 methods | **74 tests** |
| `test_computeengine` | `TestReprSvg` only | rest of module |
| `test_ui_widget` | whole module | — |

`test_ui_widget` is deliberately blunt: 19 of its 25 classes fail only **partially**, so precise marking would mean ~92 individual decorators to maintain against every new test.

**Nothing is lost where graphviz exists** — with `dot` on PATH all tests run, which is how the CI matrix job runs them on every platform.

## Docstrings

Three genuine helpers gain one — `_InstrumentBlock.value` and the `_chain` / `_count_hashes` static helpers. Their enclosing classes were already documented; only these were skipped. This is the test half of #70, which this PR supersedes; the `[tool.interrogate]` configuration that goes with it is in #71, since it lives in `pyproject.toml`.

## Verification

With `dot`: **1098 passed**. With `dot` masked from PATH: **874 passed, 196 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)